### PR TITLE
Fix anchor binding in rowing index and remove stale 'log' redirect

### DIFF
--- a/src/pages/rowing/[redirect].astro
+++ b/src/pages/rowing/[redirect].astro
@@ -14,8 +14,7 @@ export const redirects : Map<string, string> = new Map<string, string>([
         ["5k", Rowing.Logbook5kLink],
         ["10k", Rowing.Logbook10kLink],
         ["1h", Rowing.Logbook1hLink],
-        ["profile", Rowing.LogbookProfileLink],
-        ["log", Rowing.LogbookLogLink]
+        ["profile", Rowing.LogbookProfileLink]
     ]);
 
 const { redirect } = Astro.params;

--- a/src/pages/rowing/index.astro
+++ b/src/pages/rowing/index.astro
@@ -78,7 +78,7 @@ const cards: Card[] = [
     <div style="display:flex;flex-grow: 1;">
       {
         cards.map((card) => (
-          <a href="{card.link}">
+          <a href={card.link}>
             <div style="background-color:brown;color:white;width:15rem;height:10rem;margin:5rem;"><p style="vertical-align:middle;height:100%;text-center">{card.title}</p></div>
           </a>
         ))


### PR DESCRIPTION
### Motivation
- Ensure row overview links navigate correctly and remove an outdated redirect mapping for the rowing log route.

### Description
- Use proper template expression for anchor `href` in `src/pages/rowing/index.astro` so links use `card.link` instead of the literal string `"{card.link}"`.
- Remove the stale `"log"` -> `Rowing.LogbookLogLink` entry from the `redirects` map in `src/pages/rowing/[redirect].astro`.

### Testing
- Built the site with `npm run build` (Astro) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5fdad694dc8332bddea15aaf3781de)