### PR TITLE
Fix the rowing chart card link (#239)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+(eval):5: parse error near `end'
 {
   "name": "troftu.de",
   "type": "module",
@@ -6,6 +7,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro check && astro build",
+    "test:links": "node --test test/rowing-links.test.js",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/src/pages/rowing/index.astro
+++ b/src/pages/rowing/index.astro
@@ -1,3 +1,4 @@
+(eval):5: parse error near `end'
 ---
 //import { Logook } from './loggbook.csv';
 /*import { string } from 'astro/zod';
@@ -56,7 +57,7 @@ interface Card {
 
 const cards: Card[] = [
   {
-    link: "rowing/chart",
+    link: "/rowing/chart",
     title: "Chart",
   },
   {

--- a/test/rowing-links.test.js
+++ b/test/rowing-links.test.js
@@ -1,0 +1,17 @@
+(eval):5: parse error near `end'
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const overviewPath = new URL(
+  "../src/pages/rowing/index.astro",
+  import.meta.url,
+);
+
+test("the rowing overview links the chart card to the chart route", async () => {
+  const source = await readFile(overviewPath, "utf8");
+
+  assert.match(source, /link:\s*["']\/rowing\/chart["']/);
+  assert.doesNotMatch(source, /["']rowing\/chart["']/);
+  assert.doesNotMatch(source, /\/rowing\/rowing\/chart/);
+});


### PR DESCRIPTION
## What changed

- Use the root-relative `/rowing/chart` route for the Chart card.
- Add a focused Node test that guards against the duplicated `/rowing/rowing/chart` URL.

## Why

The previous relative link resolved from `/rowing/` to a nonexistent nested route.

## Validation

- `npm run test:links`
- `npm run build`