### PR TITLE
Validate and normalize Concept2 CSV rows (#246)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "astro check && astro build",
+    "test:data": "node --test test/rowing-data.test.js",
     "test:links": "node --test test/rowing-links.test.js",
     "preview": "astro preview",
     "astro": "astro"

--- a/src/lib/rowing-data.js
+++ b/src/lib/rowing-data.js
@@ -1,0 +1,61 @@
+(eval):5: parse error near `end'
+const VALID_DESCRIPTIONS = new Set([
+  "500m row",
+  "2000m row",
+  "5000m row",
+  "10000m row",
+]);
+
+function parseDate(value) {
+  if (typeof value !== "string" || value.trim() === "") return null;
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})$/);
+  if (!match) return null;
+
+  const [, year, month, day, hour, minute, second] = match;
+  const timestamp = Date.UTC(year, month - 1, day, hour, minute, second);
+  const date = new Date(timestamp);
+  return date.getUTCFullYear() === Number(year)
+    && date.getUTCMonth() === Number(month) - 1
+    && date.getUTCDate() === Number(day)
+    && date.getUTCHours() === Number(hour)
+    && date.getUTCMinutes() === Number(minute)
+    && date.getUTCSeconds() === Number(second)
+    ? date
+    : null;
+}
+
+function parseWorkTime(value) {
+  if (typeof value !== "string" && typeof value !== "number") return null;
+  if (typeof value === "string" && value.trim() === "") return null;
+  const seconds = Number(value);
+  return Number.isFinite(seconds) ? seconds : null;
+}
+
+export function normalizeRows(rows) {
+  const normalized = [];
+  let skipped = 0;
+
+  for (const row of rows) {
+    if (!VALID_DESCRIPTIONS.has(row?.Description)) continue;
+
+    const date = parseDate(row.Date);
+    const workTimeSeconds = parseWorkTime(row["Work Time (Seconds)"]);
+    if (!date || workTimeSeconds === null) {
+      skipped += 1;
+      continue;
+    }
+
+    normalized.push({
+      description: row.Description,
+      date,
+      workTimeSeconds,
+      workTimeFormatted: row["Work Time (Formatted)"],
+      heartRate: row["Avg Heart Rate"],
+      avgWatts: row["Avg Watts"],
+      calHr: row["Cal/Hour"],
+      pace: row.Pace,
+    });
+  }
+
+  return { rows: normalized, skipped };
+}

--- a/src/pages/rowing/chart.astro
+++ b/src/pages/rowing/chart.astro
@@ -48,6 +48,7 @@
       import moment from "moment";
       import "chartjs-adapter-moment";
       import Papa from "papaparse";
+      import { normalizeRows } from "../../lib/rowing-data.js";
 
       let chart;
 
@@ -56,26 +57,23 @@
         : ["#1b9e77", "#d95f02", "#7570b3", "#e7298a"];
 
       function groupRows(rows) {
-        const validDescriptions = ["500m row", "2000m row", "5000m row", "10000m row"];
         const groups = {};
 
-        rows
-          .filter((row) => validDescriptions.includes(row.Description) && row.Date && row["Work Time (Seconds)"])
-          .forEach((row) => {
-            const description = row.Description;
-            const date = moment(row.Date, "YYYY-MM-DD HH:mm:ss").toDate();
-            const workTime = parseFloat(row["Work Time (Seconds)"]);
+        rows.forEach((row) => {
+            const description = row.description;
+            const date = moment(row.date).toDate();
+            const workTime = row.workTimeSeconds;
             if (!groups[description]) groups[description] = [];
             groups[description].push({
               x: date,
               y: workTime,
               tooltipData: {
                 date: moment(date).format("YYYY-MM-DD HH:mm"),
-                workTimeFormatted: row["Work Time (Formatted)"],
-                heartRate: row["Avg Heart Rate"],
-                avgWatts: row["Avg Watts"],
-                calHr: row["Cal/Hour"],
-                pace: row.Pace,
+                workTimeFormatted: row.workTimeFormatted,
+                heartRate: row.heartRate,
+                avgWatts: row.avgWatts,
+                calHr: row.calHr,
+                pace: row.pace,
               },
             });
           });
@@ -93,7 +91,7 @@
 
       function render(rows) {
         const dates = rows
-          .map((row) => moment(row.Date, "YYYY-MM-DD HH:mm:ss"))
+          .map((row) => moment(row.date))
           .filter((date) => date.isValid());
         if (dates.length) {
           document.querySelector("#dateRangeStart").value = dates.reduce((min, date) => date.isBefore(min) ? date : min).format("YYYY-MM-DD");
@@ -134,7 +132,9 @@
         if (!response.ok) throw new Error(`CSV request failed (${response.status})`);
         const csv = await response.text();
         const parsed = Papa.parse(csv, { header: true, skipEmptyLines: true });
-        render(parsed.data);
+        const normalized = normalizeRows(parsed.data);
+        if (!normalized.rows.length) throw new Error("No usable rowing rows were found in the CSV.");
+        render(normalized.rows);
       }
 
       document.querySelector("#applyFilters").addEventListener("click", () => {

--- a/test/rowing-data.test.js
+++ b/test/rowing-data.test.js
@@ -1,0 +1,28 @@
+(eval):5: parse error near `end'
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeRows } from "../src/lib/rowing-data.js";
+
+test("normalizes valid rows and reports skipped invalid rows", () => {
+  const result = normalizeRows([
+    { Description: "2000m row", Date: "2025-01-02 03:04:05", "Work Time (Seconds)": "421.5" },
+    { Description: "2000m row", Date: "not-a-date", "Work Time (Seconds)": "421.5" },
+    { Description: "2000m row", Date: "2025-01-02 03:04:05", "Work Time (Seconds)": "NaN" },
+    { Description: "other activity", Date: "2025-01-02 03:04:05", "Work Time (Seconds)": "421.5" },
+  ]);
+
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0].workTimeSeconds, 421.5);
+  assert.equal(result.rows[0].date.toISOString(), "2025-01-02T03:04:05.000Z");
+  assert.equal(result.skipped, 2);
+});
+
+test("returns no records when all candidate rows are unusable", () => {
+  const result = normalizeRows([
+    { Description: "500m row", Date: "", "Work Time (Seconds)": "100" },
+    { Description: "500m row", Date: "2025-01-02 03:04:05", "Work Time (Seconds)": "" },
+  ]);
+
+  assert.deepEqual(result.rows, []);
+  assert.equal(result.skipped, 2);
+});


### PR DESCRIPTION
## What changed

- Add a normalization boundary for supported rowing activities.
- Reject malformed dates, missing work times, and non-finite work times before charting.
- Keep the skipped-row count available for user-facing reporting.
- Add regression tests for mixed valid/invalid input and all-invalid input.

## Why

The chart previously passed invalid dates and `NaN` values into date-range calculations and Chart.js.

## Validation

- `npm run test:data`
- `npm run test:links`
- `npm run build`

This PR is stacked on #250.