### PR TITLE
Preserve the full dataset during chart filtering (#240)

### DIFF
--- a/src/lib/rowing-data.js
+++ b/src/lib/rowing-data.js
@@ -59,3 +59,10 @@ export function normalizeRows(rows) {
 
   return { rows: normalized, skipped };
 }
+
+export function filterDataPoints(datasets, start, end) {
+  return datasets.map((dataset) => ({
+    ...dataset,
+    data: dataset.data.filter((point) => point.x >= start && point.x <= end),
+  }));
+}

--- a/src/pages/rowing/chart.astro
+++ b/src/pages/rowing/chart.astro
@@ -48,9 +48,10 @@
       import moment from "moment";
       import "chartjs-adapter-moment";
       import Papa from "papaparse";
-      import { normalizeRows } from "../../lib/rowing-data.js";
+      import { filterDataPoints, normalizeRows } from "../../lib/rowing-data.js";
 
       let chart;
+      let sourceDatasets = [];
 
       const colors = () => window.matchMedia("(prefers-color-scheme: dark)").matches
         ? ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728"]
@@ -99,10 +100,11 @@
         }
 
         const canvas = document.querySelector("#plot");
+        sourceDatasets = groupRows(rows);
         chart?.destroy();
         chart = new Chart(canvas, {
           type: "line",
-          data: { datasets: groupRows(rows) },
+          data: { datasets: filterDataPoints(sourceDatasets, new Date(-8640000000000000), new Date(8640000000000000)) },
           options: {
             responsive: true,
             maintainAspectRatio: false,
@@ -141,9 +143,7 @@
         if (!chart) return;
         const start = moment(document.querySelector("#dateRangeStart").value).startOf("day");
         const end = moment(document.querySelector("#dateRangeEnd").value).endOf("day");
-        chart.data.datasets.forEach((dataset) => {
-          dataset.data = dataset.data.filter((point) => moment(point.x).isBetween(start, end, undefined, "[]"));
-        });
+        chart.data.datasets = filterDataPoints(sourceDatasets, start.toDate(), end.toDate());
         chart.update();
       });
 

--- a/test/rowing-data.test.js
+++ b/test/rowing-data.test.js
@@ -1,7 +1,7 @@
 (eval):5: parse error near `end'
 import assert from "node:assert/strict";
 import test from "node:test";
-import { normalizeRows } from "../src/lib/rowing-data.js";
+import { filterDataPoints, normalizeRows } from "../src/lib/rowing-data.js";
 
 test("normalizes valid rows and reports skipped invalid rows", () => {
   const result = normalizeRows([
@@ -25,4 +25,22 @@ test("returns no records when all candidate rows are unusable", () => {
 
   assert.deepEqual(result.rows, []);
   assert.equal(result.skipped, 2);
+});
+
+test("filtering can narrow and then widen without losing source points", () => {
+  const datasets = [{
+    label: "2000m",
+    data: [
+      { x: new Date("2025-01-01T00:00:00Z"), y: 400 },
+      { x: new Date("2025-01-15T00:00:00Z"), y: 410 },
+      { x: new Date("2025-02-01T00:00:00Z"), y: 420 },
+    ],
+  }];
+
+  const narrow = filterDataPoints(datasets, new Date("2025-01-10T00:00:00Z"), new Date("2025-01-20T00:00:00Z"));
+  const wide = filterDataPoints(datasets, new Date("2025-01-01T00:00:00Z"), new Date("2025-02-01T00:00:00Z"));
+
+  assert.deepEqual(narrow[0].data.map((point) => point.y), [410]);
+  assert.deepEqual(wide[0].data.map((point) => point.y), [400, 410, 420]);
+  assert.deepEqual(datasets[0].data.map((point) => point.y), [400, 410, 420]);
 });


### PR DESCRIPTION
## What changed

- Keep a complete source dataset separate from displayed Chart.js datasets.
- Derive filtered datasets from the source on every filter application.
- Add a regression test covering narrow → widen behavior and source immutability.

## Why

The old handler filtered each displayed dataset in place, so broadening the range could not restore removed points.

## Validation

- `npm run test:data`
- `npm run build`

This PR is stacked on #251.