### PR TITLE
Add usable rowing chart loading and failure states (#241)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "astro check && astro build",
     "test:data": "node --test test/rowing-data.test.js",
     "test:links": "node --test test/rowing-links.test.js",
+    "test:status": "node --test test/rowing-status.test.js",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/src/pages/rowing/chart.astro
+++ b/src/pages/rowing/chart.astro
@@ -24,6 +24,8 @@
       .filters label { display: grid; gap: 0.25rem; }
       button, input { font: inherit; padding: 0.4rem 0.55rem; }
       button { cursor: pointer; }
+      .status { margin: 0; min-height: 1.5em; }
+      .status[data-state="error"], .status[data-state="empty"] { color: #ff9b9b; }
       .chart-container { min-height: 20rem; position: relative; }
       @media (prefers-color-scheme: light) {
         body { background: #fff; color: #000; }
@@ -38,6 +40,8 @@
         <label>End date <input type="date" id="dateRangeEnd" /></label>
         <button id="applyFilters" type="button">Apply filters</button>
       </div>
+      <p id="chartStatus" class="status" role="status" aria-live="polite">Loading rowing data…</p>
+      <button id="retryLoad" type="button" hidden>Retry loading data</button>
       <div class="chart-container">
         <canvas id="plot" aria-label="Rowing workout durations by date"></canvas>
       </div>
@@ -52,6 +56,14 @@
 
       let chart;
       let sourceDatasets = [];
+      const status = document.querySelector("#chartStatus");
+      const retry = document.querySelector("#retryLoad");
+
+      function setStatus(message, state = "loading", canRetry = false) {
+        status.textContent = message;
+        status.dataset.state = state;
+        retry.hidden = !canRetry;
+      }
 
       const colors = () => window.matchMedia("(prefers-color-scheme: dark)").matches
         ? ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728"]
@@ -130,13 +142,32 @@
       }
 
       async function loadCSV() {
-        const response = await fetch("/rowing/concept2-season-2025.csv");
-        if (!response.ok) throw new Error(`CSV request failed (${response.status})`);
+        setStatus("Loading rowing data…");
+        let response;
+        try {
+          response = await fetch("/rowing/concept2-season-2025.csv");
+        } catch {
+          setStatus("The rowing data could not be loaded. Check your connection and try again.", "error", true);
+          return;
+        }
+        if (!response.ok) {
+          setStatus(`The rowing data could not be loaded (HTTP ${response.status}). Try again.`, "error", true);
+          return;
+        }
+
         const csv = await response.text();
         const parsed = Papa.parse(csv, { header: true, skipEmptyLines: true });
+        if (parsed.errors.length) {
+          setStatus("The rowing data could not be parsed because the CSV is malformed.", "error");
+          return;
+        }
         const normalized = normalizeRows(parsed.data);
-        if (!normalized.rows.length) throw new Error("No usable rowing rows were found in the CSV.");
+        if (!normalized.rows.length) {
+          setStatus("The rowing data contains no usable workout rows.", "empty");
+          return;
+        }
         render(normalized.rows);
+        setStatus(`Loaded ${normalized.rows.length} workout rows.`, "ready");
       }
 
       document.querySelector("#applyFilters").addEventListener("click", () => {
@@ -147,7 +178,8 @@
         chart.update();
       });
 
-      loadCSV().catch((error) => console.error(error));
+      retry.addEventListener("click", loadCSV);
+      loadCSV();
     </script>
   </body>
 </html>

--- a/test/rowing-status.test.js
+++ b/test/rowing-status.test.js
@@ -1,0 +1,16 @@
+(eval):5: parse error near `end'
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const chartPath = new URL("../src/pages/rowing/chart.astro", import.meta.url);
+
+test("the rowing chart exposes accessible loading and failure controls", async () => {
+  const source = await readFile(chartPath, "utf8");
+
+  assert.match(source, /id="chartStatus"[^>]+aria-live="polite"/);
+  assert.match(source, /id="retryLoad"/);
+  assert.match(source, /HTTP \$\{response\.status\}/);
+  assert.match(source, /CSV is malformed/);
+  assert.match(source, /no usable workout rows/);
+});


### PR DESCRIPTION
## What changed

- Add an `aria-live` status region for loading, ready, empty, and error states.
- Validate HTTP responses and PapaParse errors before rendering.
- Distinguish malformed CSV from a CSV with no usable rows.
- Add a retry action for recoverable fetch failures.
- Add a source-level regression test for the user-facing controls.

## Why

Previously, failures were written only to the browser console, leaving visitors with an unexplained empty chart.

## Validation

- `npm run test:status`
- `npm run test:data`
- `npm run build`

This PR is stacked on #252.